### PR TITLE
Add molecule tests

### DIFF
--- a/.env.yml
+++ b/.env.yml
@@ -1,0 +1,7 @@
+---
+# Default Molecule .env.yml file
+# NOTE: to make molecule use this file, place it in the root of your project (or from whichever directory you are calling 'molecule'), and rename it to .env.yml
+PLAYBOOK_DIR: ../../../playbooks # Relative to the default molecule.yml (molecule/ext/molecule-src/molecule.yml)
+ANSIBLE_VERBOSITY: '2'
+ANSIBLE_ROLES_PATH: ../../playbooks/roles # Relative to your scenario (e.g. molecule/role-foo/..) 
+REQUIREMENTS_FILE: requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# SURF Research Cloud Molecule Testing Configuration
+
+This repository contains default configuration for running [Molecule](https://ansible.readthedocs.io/projects/molecule/) tests for SURF Research Cloud (SRC) Components and Catalog Items. The repository is meant to be included into other repositories as a subtree.
+
+## Getting Started
+
+### Requirements
+
+1. Docker and/or Podman (to spin up test containers)
+1. Python and pip
+1. Ansible
+1. Access to the [test container images](https://github.com/UtrechtUniversity/SRC-test-workspace)
+
+### Install SRC-specific configuration
+
+To add Molecule tests to your SRC component or catalog item repository, follow these steps:
+
+1. create a `molecule` directory in your repository's root: `mkdir molecule`
+1. include the contents of this repository as a subtree, under `molecule/ext/molecule-src`
+  * `git remote add molecule-src https://github.com/UtrechtUniversity/SRC-molecule.git`
+  * `git subtree add --prefix molecule/ext/molecule-src molecule-src main --squash`
+1. copy the default `.env.yml` file to your repository root: `cp molecule/ext/molecule-src/default/env.yml .env.yml`
+  * optionally edit the contents of `.env.yml`, if your playbooks are not in the default location (the repository root)
+1. run `pip install -r molecule/ext/molecule-src/requirements.txt`
+
+That's it for setup! You're now ready to start adding your own scenarios.
+
+## Adding scenarios
+
+To create a Molecule scenario to test, just create a subdirectory of the `molecule` directory, e.g.:
+
+`mkdir molecule/my-component`
+
+Now add a `molecule.yml` file to the `my-component` subdirectory, with contents like the following:
+
+```yaml
+provisioner:
+  name: ansible
+  env:
+    components:
+      - name: 'my-component'
+        path: 'my-component.yaml'
+        parameters: # Define all parameters needed by the component here
+          my_component_param1: 'Foo'
+```
+
+The above config file does not provide a `platforms` key, so tests for this scenario will use the default platforms (containers) specified in `molecule/ext/molecule-src/molecule.yml` (Ubuntu Focal and Ubuntu Jammy). You can override this by adding your own platform definition, e.g.:
+
+```yaml
+platforms:
+  - name: workspace-src-ubuntu_focal-desktop
+    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_focal-desktop
+    pre_build_image: true
+    # The following lines are an example of how to specify a container registry to pull the image from, if it is not already available locally.
+    registry:
+      url: $DOCKER_REGISTRY
+      credentials:
+        username: $DOCKER_USER
+```
+
+## Adding additional assertions

--- a/converge.yml
+++ b/converge.yml
@@ -1,0 +1,21 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  tasks:
+
+    - name: Debug -- list all components to be executed
+      ansible.builtin.debug:
+        msg: "{{ item.name }}"
+      with_items: "{{ lookup('env', 'components') }}"
+
+    - name: Test the component by executing it using ansible on the workspace
+      ansible.builtin.command: ansible-playbook --connection=local -v -b {{ remote_plugin.arguments }} --extra-vars='{{ remote_plugin.parameters }}' /rsc/plugins/{{ item.name }}/{{ item.path }}
+      register: ansible_on_workspace
+      changed_when: "'changed=0' not in ansible_on_workspace.stdout_lines[-1]"
+      vars:
+        remote_plugin:
+          script_type: 'Ansible PlayBook'
+          arguments: "-i 127.0.0.1, --skip-tags {{ ansible_skip_tags | join(',') }}"
+          parameters: "{{ item.parameters | default('{}') }}"
+      with_items: "{{ lookup('env', 'components') }}"

--- a/default.env.yml
+++ b/default.env.yml
@@ -1,0 +1,7 @@
+---
+# Default Molecule .env.yml file
+# NOTE: to make molecule use this file, place it in the root of your project (or from whichever directory you are calling 'molecule'), and rename it to .env.yml
+PLAYBOOK_DIR: ../../../ # Relative to the default molecule.yml (molecule/ext/molecule-src/molecule.yml)
+ANSIBLE_VERBOSITY: '2'
+ANSIBLE_ROLES_PATH: ../../roles # Relative to your scenario (e.g. molecule/role-foo/..) 
+REQUIREMENTS_FILE: requirements.txt

--- a/localhost_prepare.yml
+++ b/localhost_prepare.yml
@@ -1,0 +1,8 @@
+---
+# This playbook ensures that dependencies on the Ansible controller (your localhost) are installed
+
+- name: "Prepare dependencies on ansible controller"
+  hosts: "localhost"
+  tasks:
+    - name: Ensure requirements are installed
+      ansible.builtin.command: "pip install -r {{ lookup('env', 'REQUIREMENTS_FILE') }}"

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,27 @@
+---
+driver:
+  name: docker
+  image_settings: &image_settings
+    pre_build_image: true
+    registry:
+      url: $DOCKER_REGISTRY
+      credentials:
+        username: $DOCKER_USER
+        password: $DOCKER_PW
+platforms: # Test on ubuntu focal and jammy by default
+  - name: workspace-src-ubuntu_focal
+    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_focal
+    <<: *image_settings
+  - name: workspace-src-ubuntu_jammy
+    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_jammy
+    <<: *image_settings
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ../ext/molecule-src/converge.yml
+    prepare: ../ext/molecule-src/prepare.yml
+  env:
+    PLAYBOOK_DIR: ${PLAYBOOK_DIR:-"../../"}
+    ANSIBLE_VERBOSITY: ${ANSIBLE_VERBOSITY:-"2"}
+    ANSIBLE_ROLES_PATH: ${ANSIBLE_ROLES_PATH:-'../../roles'}
+    REQUIREMENTS_FILE: ${REQUIREMENTS_FILE:-"../../requirements.txt"}

--- a/molecule/patents/molecule.yml
+++ b/molecule/patents/molecule.yml
@@ -1,0 +1,6 @@
+provisioner:
+  name: ansible
+  env:
+    components:
+      - name: patents
+        path: patent.yml

--- a/prepare.yml
+++ b/prepare.yml
@@ -1,0 +1,32 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: true
+  tasks:
+
+    - name: Clone git component
+      when: item.git is defined
+      ansible.builtin.git:
+          repo: "{{ item.git }}"
+          dest: "/rsc/plugins/{{ item.name }}/"
+          refspec: "{{ item.refspec | default(omit) }}"
+      with_items: "{{ lookup('env', 'components') }}"
+
+    - name: Copy local component
+      when: item.git is not defined
+      ansible.posix.synchronize:
+        src: "{{ item.dir | default(lookup('env', 'PLAYBOOK_DIR')) }}/"
+        dest: "/rsc/plugins/{{ item.name }}/"
+        archive: false
+        recursive: true
+        rsync_opts:
+          - '--exclude=".*"'
+        ssh_connection_multiplexing: true
+      with_items: "{{ lookup('env', 'components') }}"
+
+    # Apt cache is normally updated at deploy time by the SRC-OS component.
+    # Make sure it is fresh so our tests use recent apt repo information.
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+      when: ansible_os_family == 'Debian'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# Default requirements file for running SRC molecule tests
+molecule~=6.0
+molecule-plugins @ git+https://github.com/dometto/molecule-plugins@disable_registry_login
+jmespath~=1.0
+docker~=6.0
+podman~=4.0


### PR DESCRIPTION
Adds molecule tests for the ansible playbook. To execute, run the following from the repo root:

`molecule -c molecule/ext/molecule-src/molecule.yml test -s patents`.

(you can add the `--destroy=never` flag to keep the container alive after the testrun is finished -- this will allow you to login to it using `docker exec` and debug).